### PR TITLE
Security/Group processors converted

### DIFF
--- a/core/src/Processors/Security/Group/Create.php
+++ b/core/src/Processors/Security/Group/Create.php
@@ -1,0 +1,426 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group;
+
+use MODX\Revolution\modAccessCategory;
+use MODX\Revolution\modAccessContext;
+use MODX\Revolution\modAccessPolicy;
+use MODX\Revolution\modAccessResourceGroup;
+use MODX\Revolution\modCategory;
+use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\modResourceGroup;
+use MODX\Revolution\modUser;
+use MODX\Revolution\modUserGroup;
+use MODX\Revolution\modUserGroupMember;
+use MODX\Revolution\modUserGroupRole;
+
+/**
+ * Create a user group
+ * @param string $name (optional) The name of the new user group. Defaults to Untitled User Group.
+ * @param integer $parent (optional) The ID of the parent user group. Defaults to 0.
+ * @package MODX\Revolution\Processors\Security\Group
+ */
+class Create extends modObjectCreateProcessor
+{
+    public $classKey = modUserGroup::class;
+    public $languageTopics = ['user'];
+    public $permission = 'usergroup_new';
+    public $objectType = 'user_group';
+    public $beforeSaveEvent = 'OnUserGroupBeforeFormSave';
+    public $afterSaveEvent = 'OnUserGroupFormSave';
+
+    /**
+     * @return bool
+     */
+    public function initialize()
+    {
+        $this->setDefaultProperties(['parent' => 0]);
+
+        return parent::initialize();
+    }
+
+    /**
+     * @return bool
+     * @throws \xPDO\xPDOException
+     */
+    public function beforeSave()
+    {
+        $this->setUsersIn();
+
+        $name = $this->getProperty('name');
+        if (empty($name)) {
+            $this->addFieldError('name', $this->modx->lexicon('user_group_err_ns_name'));
+        }
+        $parent = $this->getProperty('parent');
+        if (empty($parent)) {
+            $this->setProperty('parent', 0);
+        }
+
+        if ($this->doesAlreadyExist(['name' => $name])) {
+            $this->addFieldError('name', $this->modx->lexicon('user_group_err_already_exists'));
+        }
+
+        return parent::beforeSave();
+    }
+
+    /**
+     * @return bool
+     * @throws \xPDO\xPDOException
+     */
+    public function afterSave()
+    {
+        $this->setContexts();
+        if ($this->modx->hasPermission('usergroup_user_edit')) {
+            $this->setResourceGroups();
+        }
+
+        /* access wizard stuff */
+        $flush = false;
+        $users = $this->getProperty('aw_users', '');
+        if (!empty($users)) {
+            $this->addUsersViaWizard($users);
+        }
+        $contexts = $this->getProperty('aw_contexts', '');
+        if (!empty($contexts)) {
+            $contexts = is_array($contexts) ? $contexts : explode(',', $contexts);
+            $contexts = array_unique($contexts);
+
+            $adminPolicy = trim($this->getProperty('aw_manager_policy', 0));
+            if (!empty($adminPolicy)) {
+                $this->addManagerContextAccessViaWizard($adminPolicy);
+            }
+
+            $policy = trim($this->getProperty('aw_contexts_policy', 0));
+            if ($this->addContextAccessViaWizard($contexts, $policy)) {
+                $flush = true;
+            }
+
+            $resourceGroups = $this->getProperty('aw_resource_groups', '');
+            if (!empty($resourceGroups)) {
+                $this->addResourceGroupsViaWizard($resourceGroups, $contexts);
+            }
+
+            $categories = $this->getProperty('aw_categories', '');
+            if (!empty($categories)) {
+                $this->addElementCategoriesViaWizard($categories, $contexts);
+            }
+
+            $parallel = $this->getProperty('aw_parallel', false);
+            if ($parallel) {
+                $this->addParallelResourceGroup($contexts);
+            }
+        }
+
+        if ($flush) {
+            $this->modx->cacheManager->flushPermissions();
+        }
+
+        return parent::afterSave();
+    }
+
+    /**
+     * Add user groups via a wizard property, which is a comma-separated list of username:role key pairs, ie:
+     * jimbob:Member,johndoe:Administrator,marksmith
+     * If the Role is left off, it will default to the Member role.
+     * @param string|array $users
+     * @return bool
+     */
+    public function addUsersViaWizard($users)
+    {
+        $users = is_array($users) ? $users : explode(',', $users);
+        $users = array_unique($users);
+        foreach ($users as $userKey) {
+            $userKey = explode(':', $userKey);
+            $c = (int)$userKey[0] > 0 ? trim($userKey[0]) : ['username' => trim($userKey[0])];
+            /** @var modUser $user */
+            $user = $this->modx->getObject(modUser::class, $c);
+            if ($user === null) {
+                continue;
+            }
+
+            /** @var modUserGroupRole $role */
+            if (empty($userKey[1])) {
+                $userKey[1] = 'Member';
+            }
+            $c = (int)$userKey[1] > 0 ? trim($userKey[1]) : ['name' => trim($userKey[1])];
+            $role = $this->modx->getObject(modUserGroupRole::class, $c);
+            if ($role === null) {
+                continue;
+            }
+
+            /** @var modUserGroupMember $membership */
+            $membership = $this->modx->newObject(modUserGroupMember::class);
+            $membership->set('user_group', $this->object->get('id'));
+            $membership->set('member', $user->get('id'));
+            $membership->set('role', $role->get('id'));
+            $membership->save();
+        }
+
+        return true;
+    }
+
+    /**
+     * Add Manager Access via wizard property with a specified policy.
+     * @param int|string $adminPolicy
+     * @return bool
+     */
+    public function addManagerContextAccessViaWizard($adminPolicy)
+    {
+        $c = (int)$adminPolicy > 0 ? $adminPolicy : ['name' => $adminPolicy];
+        /** @var modAccessPolicy $policy */
+        $policy = $this->modx->getObject(modAccessPolicy::class, $c);
+        if (!$policy) {
+            return false;
+        }
+
+        /** @var modAccessResourceGroup $acl */
+        $acl = $this->modx->newObject(modAccessContext::class);
+        $acl->fromArray([
+            'target' => 'mgr',
+            'principal_class' => modUserGroup::class,
+            'principal' => $this->object->get('id'),
+            'authority' => 9999,
+            'policy' => $policy->get('id'),
+        ]);
+        $acl->save();
+
+        return true;
+    }
+
+    /**
+     * Add Context Access via wizard property.
+     * @param array $contexts
+     * @return boolean
+     */
+    public function addContextAccessViaWizard(array $contexts)
+    {
+        /** @var modAccessPolicy $policy */
+        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Context']);
+        if (!$policy) {
+            return false;
+        }
+
+        foreach ($contexts as $context) {
+            /** @var modAccessResourceGroup $acl */
+            $acl = $this->modx->newObject(modAccessContext::class);
+            $acl->fromArray([
+                'target' => trim($context),
+                'principal_class' => modUserGroup::class,
+                'principal' => $this->object->get('id'),
+                'authority' => 9999,
+                'policy' => $policy->get('id'),
+            ]);
+            $acl->save();
+        }
+        return true;
+    }
+
+    /**
+     * @param string|array $resourceGroupNames
+     * @param array $contexts
+     * @return boolean
+     */
+    public function addResourceGroupsViaWizard($resourceGroupNames, array $contexts)
+    {
+        $resourceGroupNames = is_array($resourceGroupNames) ? $resourceGroupNames : explode(',', $resourceGroupNames);
+        $resourceGroupNames = array_unique($resourceGroupNames);
+
+        /** @var modAccessPolicy $policy */
+        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Resource']);
+        if (!$policy) {
+            return false;
+        }
+
+        foreach ($resourceGroupNames as $resourceGroupName) {
+            /** @var modResourceGroup $resourceGroup */
+            $resourceGroup = $this->modx->getObject(modResourceGroup::class, ['name' => trim($resourceGroupName)]);
+            if (!$resourceGroup) {
+                return false;
+            }
+
+            foreach ($contexts as $context) {
+                /** @var modAccessResourceGroup $acl */
+                $acl = $this->modx->newObject(modAccessResourceGroup::class);
+                $acl->fromArray([
+                    'target' => $resourceGroup->get('id'),
+                    'principal_class' => modUserGroup::class,
+                    'principal' => $this->object->get('id'),
+                    'authority' => 9999,
+                    'policy' => $policy->get('id'),
+                    'context_key' => trim($context),
+                ]);
+                $acl->save();
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Adds a Resource Group with the same name and grants access for the specified Contexts
+     * @param array $contexts
+     * @return boolean
+     */
+    public function addParallelResourceGroup(array $contexts)
+    {
+        /** @var modResourceGroup $resourceGroup */
+        $resourceGroup = $this->modx->getObject(modResourceGroup::class, [
+            'name' => $this->object->get('name')
+        ]);
+        if (!$resourceGroup) {
+            $resourceGroup = $this->modx->newObject(modResourceGroup::class);
+            $resourceGroup->set('name', $this->object->get('name'));
+            if (!$resourceGroup->save()) {
+                return false;
+            }
+        }
+
+        /** @var modAccessPolicy $policy */
+        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Resource']);
+        if (!$policy) {
+            return false;
+        }
+
+        foreach ($contexts as $context) {
+            /** @var modAccessResourceGroup $acl */
+            $acl = $this->modx->newObject(modAccessResourceGroup::class);
+            $acl->fromArray([
+                'target' => $resourceGroup->get('id'),
+                'principal_class' => modUserGroup::class,
+                'principal' => $this->object->get('id'),
+                'authority' => 9999,
+                'policy' => $policy->get('id'),
+                'context_key' => trim($context),
+            ]);
+            $acl->save();
+        }
+        return true;
+    }
+
+    /**
+     * @param string|array $categoryNames
+     * @param array $contexts
+     * @return boolean
+     */
+    public function addElementCategoriesViaWizard($categoryNames, array $contexts)
+    {
+        $categoryNames = is_array($categoryNames) ? $categoryNames : explode(',', $categoryNames);
+        $categoryNames = array_unique($categoryNames);
+
+        /** @var modAccessPolicy $policy */
+        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Element']);
+        if (!$policy) {
+            return false;
+        }
+
+        foreach ($categoryNames as $categoryName) {
+            /** @var modCategory $category */
+            $category = $this->modx->getObject(modCategory::class, ['category' => trim($categoryName)]);
+            if (!$category) {
+                return false;
+            }
+
+            foreach ($contexts as $context) {
+                /** @var modAccessCategory $acl */
+                $acl = $this->modx->newObject(modAccessCategory::class);
+                $acl->fromArray([
+                    'target' => $category->get('id'),
+                    'principal_class' => modUserGroup::class,
+                    'principal' => $this->object->get('id'),
+                    'authority' => 9999,
+                    'policy' => $policy->get('id'),
+                    'context_key' => trim($context),
+                ]);
+                $acl->save();
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Set the users in the group
+     * @return array
+     * @throws \xPDO\xPDOException
+     */
+    public function setUsersIn()
+    {
+        $users = $this->getProperty('users');
+        $memberships = [];
+        if (!empty($users)) {
+            $users = is_array($users) ? $users : $this->modx->fromJSON($users);
+            $memberships = [];
+            foreach ($users as $userArray) {
+                if (empty($userArray['id']) || empty($userArray['role'])) {
+                    continue;
+                }
+
+                /** @var modUserGroupMember $membership */
+                $membership = $this->modx->newObject(modUserGroupMember::class);
+                $membership->set('user_group', $this->object->get('id'));
+                $membership->set('member', $userArray['id']);
+                $membership->set('role', $userArray['role']);
+                $memberships[] = $membership;
+            }
+            $this->object->addMany($memberships);
+        }
+        return $memberships;
+    }
+
+    /**
+     * Set the Context ACLs for the Group
+     * @return array
+     * @throws \xPDO\xPDOException
+     */
+    public function setContexts()
+    {
+        $contexts = $this->getProperty('contexts');
+        $access = [];
+        if (!empty($contexts)) {
+            $contexts = is_array($contexts) ? $contexts : $this->modx->fromJSON($contexts);
+            foreach ($contexts as $context) {
+                /** @var modAccessContext $acl */
+                $acl = $this->modx->newObject(modAccessContext::class);
+                $acl->fromArray($context);
+                $acl->set('principal', $this->object->get('id'));
+                $acl->set('principal_class', modUserGroup::class);
+                if ($acl->save()) {
+                    $access[] = $acl;
+                }
+            }
+        }
+        return $access;
+    }
+
+    /**
+     * Set the Resource Group ACLs for the Group
+     * @return array
+     * @throws \xPDO\xPDOException
+     */
+    public function setResourceGroups()
+    {
+        $resourceGroups = $this->getProperty('resource_groups');
+        $access = [];
+        if (!empty($resourceGroups)) {
+            $resourceGroups = is_array($resourceGroups) ? $resourceGroups : $this->modx->fromJSON($resourceGroups);
+            foreach ($resourceGroups as $resourceGroup) {
+                /** @var modAccessResourceGroup $acl */
+                $acl = $this->modx->newObject(modAccessResourceGroup::class);
+                $acl->fromArray($resourceGroup);
+                $acl->set('principal', $this->object->get('id'));
+                $acl->set('principal_class', modUserGroup::class);
+                if ($acl->save()) {
+                    $access[] = $acl;
+                }
+            }
+        }
+
+        return $access;
+    }
+}

--- a/core/src/Processors/Security/Group/GetList.php
+++ b/core/src/Processors/Security/Group/GetList.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group;
+
+use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\modUserGroup;
+use xPDO\Om\xPDOQuery;
+
+/**
+ * Gets a list of user groups
+ * @param boolean $combo (optional) If true, will append a (anonymous) row
+ * @param integer $start (optional) The record to start at. Defaults to 0.
+ * @param integer $limit (optional) The number of records to limit to. Defaults to 10.
+ * @param string $sort (optional) The column to sort by. Defaults to name.
+ * @param string $dir (optional) The direction of the sort. Defaults to ASC.
+ * @package MODX\Revolution\Processors\Security\Group
+ */
+class GetList extends modObjectGetListProcessor
+{
+    public $classKey = modUserGroup::class;
+    public $languageTopics = ['user', 'access', 'messages'];
+    public $permission = 'usergroup_view';
+
+    /**
+     * @return bool
+     */
+    public function initialize()
+    {
+        $initialized = parent::initialize();
+        $this->setDefaultProperties([
+            'addAll' => false,
+            'addNone' => false,
+            'combo' => false,
+        ]);
+        
+        return $initialized;
+    }
+
+    /**
+     * @param array $list
+     * @return array
+     */
+    public function beforeIteration(array $list)
+    {
+        $query = $this->getProperty('query', '');
+        $parent = $this->getProperty('parent', ''); // avoid 0 which is also a parent
+        if (!empty($query) || $parent !== '') {
+            return $list;
+        }
+        if ($this->getProperty('addAll', false)) {
+            $list[] = [
+                'id' => '',
+                'name' => '(' . $this->modx->lexicon('all') . ')',
+                'description' => '',
+                'parent' => '',
+            ];
+        }
+        if ($this->getProperty('addNone', false)) {
+            $list[] = [
+                'id' => 0,
+                'name' => $this->modx->lexicon('none'),
+                'description' => '',
+                'parent' => 0,
+            ];
+        }
+        if ($this->getProperty('combo', false)) {
+            $list[] = [
+                'id' => '',
+                'name' => ' (' . $this->modx->lexicon('anonymous') . ') ',
+                'description' => '',
+                'parent' => 0,
+            ];
+        }
+
+        return $list;
+    }
+
+    /**
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
+    public function prepareQueryBeforeCount(xPDOQuery $c)
+    {
+        $exclude = $this->getProperty('exclude', '');
+        if (!empty($exclude)) {
+            $c->where([
+                'id:NOT IN' => is_array($exclude) ? $exclude : explode(',', $exclude),
+            ]);
+        }
+        $parent = $this->getProperty('parent', '');
+        if (!empty($parent)) {
+            $c->where(['parent' => $parent]);
+        }
+        $query = $this->getProperty('query', '');
+        if (!empty($query)) {
+            $c->where([
+                'name:LIKE' => '%' . $query . '%',
+                'OR:description:LIKE' => '%' . $query . '%',
+            ]);
+        }
+        $c->sortby('parent', 'asc');
+        $c->sortby('id', 'asc');
+        
+        return $c;
+    }
+}

--- a/core/src/Processors/Security/Group/GetNodes.php
+++ b/core/src/Processors/Security/Group/GetNodes.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group;
+
+use MODX\Revolution\modProcessor;
+use MODX\Revolution\modUserGroup;
+
+/**
+ * Get the user groups in tree node format
+ * @param string $id The parent ID
+ * @package MODX\Revolution\Processors\Security\Group
+ */
+class GetNodes extends modProcessor
+{
+    /** @var string $id */
+    public $id;
+
+    /** @var modUserGroup $userGroup */
+    public $userGroup;
+
+    /**
+     * {@inheritDoc}
+     * @return boolean
+     */
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('usergroup_view');
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return array
+     */
+    public function getLanguageTopics()
+    {
+        return ['user'];
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return mixed
+     */
+    public function initialize()
+    {
+        $this->setDefaultProperties([
+            'id' => 0,
+            'sort' => 'name',
+            'dir' => 'ASC',
+            'showAnonymous' => true,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return mixed
+     */
+    public function process()
+    {
+        $this->id = $this->parseId($this->getProperty('id'));
+
+        $groups = $this->getGroups();
+
+        $list = [];
+        $list = $this->addAnonymous($list);
+
+        /** @var modUserGroup $group */
+        foreach ($groups['results'] as $group) {
+            $groupArray = $this->prepareGroup($group);
+            if (!empty($groupArray)) {
+                $list[] = $groupArray;
+            }
+        }
+
+        return $this->toJSON($list);
+    }
+
+    /**
+     * Parse the ID to get the parent group
+     * @param string $id
+     * @return mixed
+     */
+    protected function parseId($id)
+    {
+        return str_replace('n_ug_', '', $id);
+    }
+
+    /**
+     * Get the User Groups within the filter
+     * @return array
+     */
+    public function getGroups()
+    {
+        $data = [];
+        $c = $this->modx->newQuery(modUserGroup::class);
+        $c->where(['parent' => $this->id]);
+        $data['total'] = $this->modx->getCount(modUserGroup::class, $c);
+        $c->sortby($this->getProperty('sort'), $this->getProperty('dir'));
+        $data['results'] = $this->modx->getCollection(modUserGroup::class, $c);
+
+        return $data;
+    }
+
+    /**
+     * Add the Anonymous group to the list
+     * @param array $list
+     * @return array
+     */
+    public function addAnonymous(array $list)
+    {
+        if ($this->getProperty('showAnonymous') && empty($this->id)) {
+            $cls = 'pupdate';
+            $list[] = [
+                'text' => '(' . $this->modx->lexicon('anonymous') . ')',
+                'id' => 'n_ug_0',
+                'leaf' => true,
+                'type' => 'usergroup',
+                'cls' => $cls,
+                'iconCls' => 'icon icon-group',
+            ];
+        }
+
+        return $list;
+    }
+
+    /**
+     * Prepare a User Group for listing
+     * @param modUserGroup $group
+     * @return array
+     */
+    public function prepareGroup(modUserGroup $group)
+    {
+        $cls = 'padduser pcreate pupdate';
+        if ($group->get('id') != 1) {
+            $cls .= ' premove';
+        }
+        $c = $this->modx->newQuery(modUserGroup::class);
+        $c->where(['parent' => $group->get('id')]);
+        $c->limit(1);
+        $count = $this->modx->getCount(modUserGroup::class, $c);
+        return [
+            'text' => htmlentities($group->get('name'), ENT_QUOTES, 'UTF-8') . ' (' . $group->get('id') . ')',
+            'id' => 'n_ug_' . $group->get('id'),
+            'leaf' => $count <= 0,
+            'type' => 'usergroup',
+            'qtip' => $group->get('description'),
+            'cls' => $cls,
+            'iconCls' => 'icon icon-group',
+        ];
+    }
+
+}

--- a/core/src/Processors/Security/Group/Remove.php
+++ b/core/src/Processors/Security/Group/Remove.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group;
+
+use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\modUserGroup;
+
+/**
+ * Remove a user group
+ * @param integer $id The ID of the user group
+ * @package MODX\Revolution\Processors\Security\Group
+ */
+class Remove extends modObjectRemoveProcessor
+{
+    public $classKey = modUserGroup::class;
+    public $languageTopics = ['user'];
+    public $permission = 'usergroup_delete';
+    public $objectType = 'user_group';
+    public $beforeRemoveEvent = 'OnUserGroupBeforeFormRemove';
+    public $afterRemoveEvent = 'OnUserGroupFormRemove';
+
+    /**
+     * @return bool|string|null
+     */
+    public function beforeRemove()
+    {
+        if ($this->isAdminGroup()) {
+            return $this->modx->lexicon('user_group_err_remove_admin');
+        }
+
+        return parent::beforeRemove();
+    }
+
+    /**
+     * See if this User Group is the Administrator group
+     * @return boolean
+     */
+    public function isAdminGroup()
+    {
+        return $this->object->get('id') === 1 || $this->object->get('name') === $this->modx->lexicon('administrator');
+    }
+}

--- a/core/src/Processors/Security/Group/Setting/Create.php
+++ b/core/src/Processors/Security/Group/Setting/Create.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group\Setting;
+
+// @todo: replace by proper class when setting processors will be converted
+use modSystemSettingsCreateProcessor;
+use MODX\Revolution\modUserGroupSetting;
+
+/**
+ * Create a User Group setting
+ * @param integer $group/$fk The group to create the setting for
+ * @param string $key The setting key
+ * @param string $value The value of the setting
+ * @param string $name The lexicon name for the setting
+ * @param string $description The lexicon description for the setting
+ * @param string $area The area for the setting
+ * @param string $namespace The namespace for the setting
+ * @package MODX\Revolution\Processors\Security\Group\Setting
+ */
+class Create extends modSystemSettingsCreateProcessor
+{
+    public $classKey = modUserGroupSetting::class;
+    public $languageTopics = ['setting', 'namespace', 'user'];
+
+    /**
+     * @return bool
+     */
+    public function beforeSave()
+    {
+        $group = (int)$this->getProperty('fk', $this->getProperty('group', 0));
+        if (!$group) {
+            $this->addFieldError('fk', $this->modx->lexicon('user_group_err_ns'));
+        }
+        $this->object->set('group', $group);
+
+        return parent::beforeSave();
+    }
+
+    /**
+     * Check to see if a Setting already exists with this key and user group
+     * @return boolean
+     */
+    public function alreadyExists()
+    {
+        return $this->doesAlreadyExist([
+            'key' => $this->object->get('key'),
+            'group' => $this->object->get('group'),
+        ]);
+    }
+}

--- a/core/src/Processors/Security/Group/Setting/GetList.php
+++ b/core/src/Processors/Security/Group/Setting/GetList.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group\Setting;
+
+// @todo: replace by proper class when setting processors will be converted
+use modSystemSettingsGetListProcessor;
+use MODX\Revolution\modUserGroupSetting;
+
+/**
+ * Gets a list of user group settings
+ * @param integer $group The group to grab from
+ * @param integer $start (optional) The record to start at. Defaults to 0.
+ * @param integer $limit (optional) The number of records to limit to. Defaults to 10.
+ * @param string $sort (optional) The column to sort by. Defaults to key.
+ * @param string $dir (optional) The direction of the sort. Defaults to ASC.
+ * @package MODX\Revolution\Processors\Security\Group\Setting
+ */
+class GetList extends modSystemSettingsGetListProcessor
+{
+    public $classKey = modUserGroupSetting::class;
+
+    /**
+     * @return bool
+     */
+    public function initialize()
+    {
+        $this->setDefaultProperties(['group' => 0]);
+
+        return parent::initialize();
+    }
+
+    /**
+     * Filter by user group
+     * @return array
+     */
+    public function prepareCriteria()
+    {
+        $criteria = [];
+        $criteria[] = ['group' => (int)$this->getProperty('group')];
+
+        return $criteria;
+    }
+
+}

--- a/core/src/Processors/Security/Group/Setting/Remove.php
+++ b/core/src/Processors/Security/Group/Setting/Remove.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group\Setting;
+
+// @todo: replace by proper class when setting processors will be converted
+use modSystemSettingsRemoveProcessor;
+use MODX\Revolution\modAccessibleObject;
+use MODX\Revolution\modUserGroupSetting;
+
+/**
+ * Remove a user group setting and its lexicon strings
+ * @param integer $group The group associated to the setting
+ * @param string $key The setting key
+ * @package MODX\Revolution\Processors\Security\Group\Setting
+ */
+class Remove extends modSystemSettingsRemoveProcessor
+{
+    public $classKey = modUserGroupSetting::class;
+
+    /**
+     * @return bool
+     */
+    public function initialize()
+    {
+        $key = $this->getProperty('key', '');
+        $group = (int)$this->getProperty('group', 0);
+
+        if (empty($key) || !$group) {
+            return $this->modx->lexicon($this->objectType . '_err_ns');
+        }
+
+        $primaryKey = ['key' => $key, 'group' => $group];
+        $this->object = $this->modx->getObject($this->classKey, $primaryKey);
+
+        if (!$this->object) {
+            return $this->modx->lexicon($this->objectType . '_err_nf');
+        }
+
+        if ($this->checkRemovePermission && $this->object instanceof modAccessibleObject && !$this->object->checkPolicy('remove')) {
+            return $this->modx->lexicon('access_denied');
+        }
+
+        return true;
+    }
+}

--- a/core/src/Processors/Security/Group/Setting/Update.php
+++ b/core/src/Processors/Security/Group/Setting/Update.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group\Setting;
+
+// @todo: replace by proper class when setting processors will be converted
+use modSystemSettingsUpdateProcessor;
+use MODX\Revolution\modAccessibleObject;
+use MODX\Revolution\modUserGroupSetting;
+
+/**
+ * Update a user group setting
+ * @param integer $fk The group ID to create the setting for
+ * @param string $key The setting key
+ * @param string $value The setting value
+ * @package MODX\Revolution\Processors\Security\Group\Setting
+ */
+class Update extends modSystemSettingsUpdateProcessor
+{
+    public $classKey = modUserGroupSetting::class;
+    public $languageTopics = ['setting', 'user'];
+    public $permission = ['usergroup_save' => true, 'settings' => true];
+
+    /**
+     * @return bool|string|null
+     */
+    public function initialize()
+    {
+        $group = (int)$this->getProperty('fk', 0);
+        if (!$group) {
+            return $this->modx->lexicon('user_group_err_ns');
+        }
+
+        $key = $this->getProperty('key', '');
+        if (empty($key)) {
+            return $this->modx->lexicon($this->objectType . '_err_ns');
+        }
+
+        $this->object = $this->modx->getObject($this->classKey, ['key' => $key, 'group' => $group]);
+
+        if (!$this->object) {
+            return $this->modx->lexicon($this->objectType . '_err_nf');
+        }
+
+        if ($this->checkSavePermission && $this->object instanceof modAccessibleObject && !$this->object->checkPolicy('save')) {
+            return $this->modx->lexicon('access_denied');
+        }
+
+        return true;
+    }
+}

--- a/core/src/Processors/Security/Group/Setting/UpdateFromGrid.php
+++ b/core/src/Processors/Security/Group/Setting/UpdateFromGrid.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group\Setting;
+
+// @todo: replace by proper class when setting processors will be converted
+use modUserGroupSettingUpdateProcessor;
+
+/**
+ * Update a user group setting from a grid
+ * @param integer $group The group to create the setting for
+ * @param string $key The setting key
+ * @param string $value The setting value
+ * @package MODX\Revolution\Processors\Security\Group\Setting
+ */
+class UpdateFromGrid extends modUserGroupSettingUpdateProcessor
+{
+    /**
+     * @return bool|string|null
+     * @throws \xPDO\xPDOException
+     */
+    public function initialize()
+    {
+        $data = $this->getProperty('data');
+        if (empty($data)) {
+            return $this->modx->lexicon('invalid_data');
+        }
+        $properties = $this->modx->fromJSON($data);
+        $this->setProperties($properties);
+        $this->unsetProperty('data');
+        $this->setDefaultProperties(['fk' => $this->getProperty('group')]);
+
+        return parent::initialize();
+    }
+}

--- a/core/src/Processors/Security/Group/Sort.php
+++ b/core/src/Processors/Security/Group/Sort.php
@@ -1,0 +1,215 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group;
+
+use MODX\Revolution\modProcessor;
+use MODX\Revolution\modUser;
+use MODX\Revolution\modUserGroup;
+use MODX\Revolution\modUserGroupMember;
+use MODX\Revolution\modX;
+
+/**
+ * Sort users and user groups, effectively repositioning users into proper groups
+ * @param string $data The encoded in JSON tree data
+ * @package MODX\Revolution\Processors\Security\Group
+ */
+class Sort extends modProcessor
+{
+    /**
+     * @return bool
+     */
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('usergroup_save');
+    }
+
+    /**
+     * @return array
+     */
+    public function getLanguageTopics()
+    {
+        return ['user'];
+    }
+
+    /**
+     * @return array|mixed|string
+     * @throws \xPDO\xPDOException
+     */
+    public function process()
+    {
+        $data = $this->getProperty('data');
+        if (empty($data)) {
+            return $this->failure($this->modx->lexicon('invalid_data'));
+        }
+        $data = urldecode($data);
+        $data = $this->modx->fromJSON($data);
+        if (empty($data)) {
+            return $this->failure($this->modx->lexicon('invalid_data'));
+        }
+
+        $this->sortGroups($data);
+        if ($this->modx->hasPermission('usergroup_user_edit')) {
+            $this->sortUsers($data);
+        }
+
+        return $this->success();
+    }
+
+    /**
+     * Sort and rearrange any groups in the data
+     * @param array $data
+     * @return void
+     */
+    public function sortGroups(array $data)
+    {
+        $groups = [];
+        $this->getGroupsFormatted($groups, $data);
+
+        /* readjust groups */
+        foreach ($groups as $groupArray) {
+            if (!empty($groupArray['id'])) {
+                /** @var modUserGroup $userGroup */
+                $userGroup = $this->modx->getObject(modUserGroup::class, $groupArray['id']);
+                if ($userGroup === null) {
+                    $this->modx->log(modX::LOG_LEVEL_ERROR,
+                        'Could not sort group ' . $groupArray['id'] . ' because it could not be found.');
+                    continue;
+                }
+                $oldParentId = $userGroup->get('parent');
+            } else {
+                $userGroup = $this->modx->newObject(modUserGroup::class);
+                $oldParentId = 0;
+            }
+
+            if ($groupArray['parent'] === $userGroup->get('id')) {
+                continue;
+            }
+
+            if ($groupArray['parent'] === 0 || $oldParentId !== $groupArray['parent']) {
+                /* get new parent, if invalid, skip, unless is root */
+                if ($groupArray['parent'] !== 0) {
+                    /** @var modUserGroup $parentUserGroup */
+                    $parentUserGroup = $this->modx->getObject(modUserGroup::class, $groupArray['parent']);
+                    if ($parentUserGroup === null) {
+                        continue;
+                    }
+                    $depth = $parentUserGroup->get('depth') + 1;
+                } else {
+                    $depth = 0;
+                }
+
+                /* save new parent and depth */
+                $userGroup->set('parent', $groupArray['parent']);
+                $userGroup->set('depth', $depth);
+            }
+            if ($groupArray['id'] !== 0) {
+                $userGroup->save();
+            }
+        }
+    }
+
+    /**
+     * Sort and rearrange any users in the data
+     * @param array $data
+     * @return void
+     */
+    public function sortUsers(array $data)
+    {
+        $users = [];
+        $this->getUsersFormatted($users, $data);
+        /* readjust users */
+        foreach ($users as $userArray) {
+            if (empty($userArray['id'])) {
+                continue;
+            }
+            /** @var modUser $user */
+            $user = $this->modx->getObject(modUser::class, $userArray['id']);
+            if ($user === null) {
+                continue;
+            }
+
+            /* get new parent, if invalid, skip, unless is root */
+            if ($userArray['new_group'] !== 0 && $userArray['new_group'] !== $userArray['old_group']) {
+                /** @var modUserGroup $membership */
+                $membership = $this->modx->getObject(modUserGroupMember::class, [
+                    'user_group' => $userArray['new_group'],
+                    'member' => $user->get('id'),
+                ]);
+                if ($membership === null) {
+                    $membership = $this->modx->newObject(modUserGroupMember::class);
+                    $membership->set('user_group', $userArray['new_group']);
+                }
+                $membership->set('member', $user->get('id'));
+                if ($membership->save()) {
+                    /* remove user from old group */
+                    if (!empty($userArray['old_group'])) {
+                        /** @var modUserGroup $oldMembership */
+                        $oldMembership = $this->modx->getObject(modUserGroupMember::class, [
+                            'user_group' => $userArray['old_group'],
+                            'member' => $user->get('id'),
+                        ]);
+                        if ($oldMembership) {
+                            $oldMembership->remove();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $ar_nodes
+     * @param $cur_level
+     * @param int $parent
+     */
+    protected function getGroupsFormatted(&$ar_nodes, $cur_level, $parent = 0)
+    {
+        $order = 0;
+        foreach ($cur_level as $id => $children) {
+            $id = substr($id, 2); /* get rid of CSS id n_ prefix */
+            if (substr($id, 0, 2) === 'ug') {
+                $ar_nodes[] = [
+                    'id' => substr($id, 3),
+                    'parent' => substr($parent, 3),
+                    'order' => $order,
+                ];
+                $order++;
+            }
+            $this->getGroupsFormatted($ar_nodes, $children, $id);
+        }
+    }
+
+    /**
+     * @param $ar_nodes
+     * @param $cur_level
+     * @param int $parent
+     */
+    protected function getUsersFormatted(&$ar_nodes, $cur_level, $parent = 0)
+    {
+        $order = 0;
+        foreach ($cur_level as $id => $children) {
+            $id = substr($id, 2); /* get rid of CSS id n_ prefix */
+            if (substr($id, 0, 4) === 'user') {
+                $userMap = substr($id, 5);
+                $userMap = explode('_', $userMap);
+                $ar_nodes[] = [
+                    'id' => $userMap[0],
+                    'old_group' => $userMap[1],
+                    'new_group' => substr($parent, 3),
+                    'order' => $order,
+                ];
+                $order++;
+            }
+            $this->getUsersFormatted($ar_nodes, $children, $id);
+        }
+    }
+
+}

--- a/core/src/Processors/Security/Group/Update.php
+++ b/core/src/Processors/Security/Group/Update.php
@@ -1,0 +1,182 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group;
+
+use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\modUserGroup;
+use MODX\Revolution\modUserGroupMember;
+
+/**
+ * Update a user group
+ * @param integer $id The ID of the user group
+ * @param string $name The new name of the user group
+ * @package MODX\Revolution\Processors\Security\Group
+ */
+class Update extends modObjectUpdateProcessor
+{
+    public $classKey = modUserGroup::class;
+    public $languageTopics = ['user'];
+    public $permission = 'usergroup_save';
+    public $objectType = 'user_group';
+    public $beforeSaveEvent = 'OnUserGroupBeforeFormSave';
+    public $afterSaveEvent = 'OnUserGroupFormSave';
+
+    /**
+     * Override the modObjectUpdateProcessor::initialize method to allow for grabbing the (anonymous) user group
+     * @return boolean|string
+     */
+    public function initialize()
+    {
+        $id = $this->getProperty('id', false);
+        if (empty($id)) {
+            $this->object = $this->modx->newObject(modUserGroup::class);
+            $this->object->set('id', 0);
+        } else {
+            $this->object = $this->modx->getObject(modUserGroup::class, $id);
+            if ($this->object === null) {
+                return $this->modx->lexicon('user_group_err_not_found');
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Override the saveObject method to prevent saving of the (anonymous) group
+     * {@inheritDoc}
+     * @return boolean
+     */
+    public function saveObject()
+    {
+        $saved = true;
+        if (!in_array($this->getProperty('id'), ['0', 0, null])) {
+            $saved = $this->object->save();
+        }
+
+        return $saved;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function beforeSave()
+    {
+        $c = $this->modx->newQuery(modUserGroup::class);
+        $c->where([
+            'id:!=' => $this->object->get('id'),
+            'name' => $this->getProperty('name')
+        ]);
+
+        $count = $this->modx->getCount(modUserGroup::class, $c);
+        if ($count > 0) {
+            return $this->modx->lexicon('user_group_err_already_exists');
+        }
+
+        return parent::beforeSave();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function afterSave()
+    {
+        if ($this->modx->hasPermission('usergroup_user_edit')) {
+            $this->addUsers();
+        }
+
+        return parent::afterSave();
+    }
+
+    /**
+     * Add users to the User Group
+     * @return modUserGroupMember[]
+     */
+    public function addUsers()
+    {
+        $users = $this->getProperty('users');
+        $id = $this->getProperty('id');
+        $memberships = [];
+        $flush = false;
+
+        if ($users !== null && !empty($id)) {
+            $users = is_array($users) ? $users : json_decode($users, true);
+
+            $currentUsers = [];
+            $currentUserIds = [];
+            foreach ($users as $user) {
+                $currentUsers[$user['id']] = $user;
+                $currentUserIds[] = $user['id'];
+            }
+
+            $remainingUserIds = [];
+            /** @var modUserGroupMember[] $existingMemberships */
+            $existingMemberships = $this->object->getMany('UserGroupMembers');
+            foreach ($existingMemberships as $existingMembership) {
+                if (!in_array($existingMembership->get('member'), $currentUserIds)) {
+                    $existingMembership->remove();
+                } else {
+                    $existingUser = $currentUsers[$existingMembership->get('member')];
+                    $existingMembership->fromArray(['role' => $existingUser['role']]);
+                    $remainingUserIds[] = $existingMembership->get('member');
+                }
+            }
+
+            $newUserIds = array_diff($currentUserIds, $remainingUserIds);
+            $newUsers = [];
+            foreach ($users as $user) {
+                if (in_array($user['id'], $newUserIds)) {
+                    $newUsers[] = $user;
+                }
+            }
+
+            foreach ($newUsers as $newUser) {
+                /** @var modUserGroupMember $membership */
+                $membership = $this->modx->newObject(modUserGroupMember::class);
+                $membership->fromArray([
+                    'user_group' => $this->object->get('id'),
+                    'role' => empty($newUser['role']) ? 0 : $newUser['role'],
+                    'member' => $newUser['id']
+                ]);
+
+                $user = $this->modx->getObject(modUser::class, $newUser['id']);
+                /* invoke OnUserBeforeAddToGroup event */
+                $OnUserBeforeAddToGroup = $this->modx->invokeEvent('OnUserBeforeAddToGroup', [
+                    'user' => &$user,
+                    'usergroup' => &$this->object,
+                    'membership' => &$membership,
+                ]);
+                $canSave = $this->processEventResponse($OnUserBeforeAddToGroup);
+                if (!empty($canSave)) {
+                    return $this->failure($canSave);
+                }
+
+                if ($membership->save()) {
+                    $memberships[] = $membership;
+                } else {
+                    return $this->failure($this->modx->lexicon('user_group_member_err_save'));
+                }
+
+                /* invoke OnUserAddToGroup event */
+                $this->modx->invokeEvent('OnUserAddToGroup', [
+                    'user' => &$user,
+                    'usergroup' => &$this->object,
+                    'membership' => &$membership,
+                ]);
+            }
+            $flush = true;
+        }
+        if ($flush) {
+            $this->modx->cacheManager->flushPermissions();
+        }
+
+        return $memberships;
+    }
+}

--- a/core/src/Processors/Security/Group/User/Create.php
+++ b/core/src/Processors/Security/Group/User/Create.php
@@ -1,0 +1,163 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group\User;
+
+use MODX\Revolution\modProcessor;
+use MODX\Revolution\modUser;
+use MODX\Revolution\modUserGroup;
+use MODX\Revolution\modUserGroupMember;
+use MODX\Revolution\modUserGroupRole;
+
+/**
+ * Add a user to a user group
+ * @param integer $usergroup The ID of the user group
+ * @param integer $user The ID of the user
+ * @param integer $role The ID of the role
+ * @package MODX\Revolution\Processors\Security\Group\User
+ */
+class Create extends modProcessor
+{
+    /** @var modUser $user */
+    public $user;
+
+    /** @var modUserGroup $userGroup */
+    public $userGroup;
+
+    /** @var modUserGroupRole $role */
+    public $role;
+
+    /**
+     * @return bool
+     */
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('usergroup_user_edit');
+    }
+
+    /**
+     * @return array
+     */
+    public function getLanguageTopics()
+    {
+        return ['user'];
+    }
+
+    /**
+     * @return bool
+     */
+    public function initialize()
+    {
+        $this->setDefaultProperties([
+            'user' => false,
+            'usergroup' => false,
+            'role' => false,
+        ]);
+
+        return true;
+    }
+
+    public function process()
+    {
+        $fields = $this->getProperties();
+        if (!$this->validate($fields)) {
+            return $this->failure();
+        }
+
+        /* create membership */
+        /** @var modUserGroupMember $membership */
+        $membership = $this->modx->newObject(modUserGroupMember::class);
+        $membership->set('user_group', $this->userGroup->get('id'));
+        $membership->set('member', $this->user->get('id'));
+        $membership->set('role', $fields['role']);
+
+        $rank = $this->getNewRank();
+        $membership->set('rank', $rank);
+
+        /* save membership */
+        if ($membership->save() === false) {
+            return $this->failure($this->modx->lexicon('user_group_member_err_save'));
+        }
+
+        /* set as primary group if the only group for user */
+        if ($rank === 0) {
+            $this->user->set('primary_group', $this->userGroup->get('id'));
+            $this->user->save();
+        }
+
+        return $this->success('', $membership);
+    }
+
+    /**
+     * @param array $fields
+     * @return bool
+     */
+    public function validate(array $fields)
+    {
+        /* get user */
+        if (empty($fields['user'])) {
+            $this->addFieldError('user', $this->modx->lexicon('user_err_ns'));
+        } else {
+            $this->user = $this->modx->getObject(modUser::class, $fields['user']);
+            if (!$this->user) {
+                $this->addFieldError('user', $this->modx->lexicon('user_err_ns'));
+            }
+        }
+
+        /* get user group */
+        if (empty($fields['usergroup'])) {
+            $this->addFieldError('user', $this->modx->lexicon('user_group_err_ns'));
+        } else {
+            $this->userGroup = $this->modx->getObject(modUserGroup::class, $fields['usergroup']);
+            if (!$this->userGroup) {
+                $this->addFieldError('user', $this->modx->lexicon('user_group_err_nf'));
+            }
+        }
+
+        /* check role */
+        if (!empty($fields['role'])) {
+            $this->role = $this->modx->getObject(modUserGroupRole::class, $fields['role']);
+            if (!$this->role) {
+                $this->addFieldError('role', $this->modx->lexicon('role_err_nf'));
+            }
+        }
+
+        if ($this->alreadyExists($fields)) {
+            $this->addFieldError('user', $this->modx->lexicon('user_group_member_err_already_in'));
+        }
+
+        return !$this->hasErrors();
+    }
+
+    /**
+     * @param array $fields
+     * @return bool
+     */
+    public function alreadyExists(array $fields)
+    {
+        if (empty($fields['user']) || empty($fields['usergroup'])) {
+            return false;
+        }
+
+        /* check to see if member is already in group */
+        return $this->modx->getCount(modUserGroupMember::class, [
+                'user_group' => $fields['usergroup'],
+                'member' => $fields['user'],
+            ]) > 0;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNewRank()
+    {
+        return $this->modx->getCount(modUserGroupMember::class, ['member' => $this->user->get('id')]);
+    }
+}

--- a/core/src/Processors/Security/Group/User/GetList.php
+++ b/core/src/Processors/Security/Group/User/GetList.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group\User;
+
+use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\modUser;
+use MODX\Revolution\modUserGroup;
+use MODX\Revolution\modUserGroupMember;
+use MODX\Revolution\modUserGroupRole;
+use xPDO\Om\xPDOObject;
+use xPDO\Om\xPDOQuery;
+
+/**
+ * Gets a list of users in a usergroup
+ * @param boolean $combo (optional) If true, will append a (anonymous) row
+ * @param integer $start (optional) The record to start at. Defaults to 0.
+ * @param integer $limit (optional) The number of records to limit to. Defaults to 10.
+ * @param string $sort (optional) The column to sort by. Defaults to name.
+ * @param string $dir (optional) The direction of the sort. Defaults to ASC.
+ * @package MODX\Revolution\Processors\Security\Group\User
+ */
+class GetList extends modObjectGetListProcessor
+{
+    public $classKey = modUser::class;
+    public $defaultSortField = 'username';
+    public $permission = 'usergroup_user_list';
+    public $languageTopics = ['user'];
+
+    /**
+     * @return bool
+     */
+    public function initialize()
+    {
+        $this->setDefaultProperties([
+            'usergroup' => false,
+            'username' => '',
+        ]);
+
+        return parent::initialize();
+    }
+
+    /**
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
+    public function prepareQueryBeforeCount(xPDOQuery $c)
+    {
+        $c->innerJoin(modUserGroupMember::class, 'UserGroupMembers');
+        $c->innerJoin(modUserGroup::class, 'UserGroup', 'UserGroupMembers.user_group = UserGroup.id');
+        $c->leftJoin(modUserGroupRole::class, 'UserGroupRole', 'UserGroupMembers.role = UserGroupRole.id');
+
+        $userGroup = $this->getProperty('usergroup', 0);
+        $c->where(['UserGroupMembers.user_group' => $userGroup]);
+
+        $username = $this->getProperty('username', '');
+        if (!empty($username)) {
+            $c->where([
+                $this->classKey . '.username:LIKE' => '%' . $username . '%',
+            ]);
+        }
+
+        return $c;
+    }
+
+    /**
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
+    public function prepareQueryAfterCount(xPDOQuery $c)
+    {
+        $c->select($this->modx->getSelectColumns($this->classKey, $this->classKey));
+        $c->select([
+            'usergroup' => 'UserGroup.id',
+            'usergroup_name' => 'UserGroup.name',
+            'role' => 'UserGroupRole.id',
+            'role_name' => 'UserGroupRole.name',
+            'authority' => 'UserGroupRole.authority',
+        ]);
+        if ($this->getProperty('sort') !== 'authority') {
+            $c->sortby('authority', 'ASC');
+        }
+
+        return $c;
+    }
+
+    /**
+     * @param xPDOObject $object
+     * @return array
+     */
+    public function prepareRow(xPDOObject $object)
+    {
+        $objectArray = $object->toArray();
+        $objectArray['role_name'] .= ' - ' . $objectArray['authority'];
+        
+        return $objectArray;
+    }
+}

--- a/core/src/Processors/Security/Group/User/Remove.php
+++ b/core/src/Processors/Security/Group/User/Remove.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group\User;
+
+use MODX\Revolution\modProcessor;
+use MODX\Revolution\modUser;
+use MODX\Revolution\modUserGroup;
+use MODX\Revolution\modUserGroupMember;
+
+/**
+ * Remove a user from a user group
+ * @param integer $usergroup The ID of the user group
+ * @param integer $user The ID of the user
+ * @package MODX\Revolution\Processors\Security\Group\User
+ */
+class Remove extends modProcessor
+{
+    /** @var modUserGroupMember $membership */
+    public $membership;
+
+    /**
+     * @return bool
+     */
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('usergroup_user_edit');
+    }
+
+    /**
+     * @return array
+     */
+    public function getLanguageTopics()
+    {
+        return ['user'];
+    }
+
+    /**
+     * @return bool|string|null
+     */
+    public function initialize()
+    {
+        $this->membership = $this->modx->getObject(modUserGroupMember::class, [
+            'member' => $this->getProperty('user', 0),
+            'user_group' => $this->getProperty('usergroup', 0),
+        ]);
+        if ($this->membership === null) {
+            return $this->modx->lexicon('user_group_member_err_nf');
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array|mixed|string
+     */
+    public function process()
+    {
+        /** @var modUserGroup $userGroup */
+        $userGroup = $this->membership->getOne('UserGroup');
+
+        /** @var modUser $user */
+        $user = $this->membership->getOne('User');
+
+        /* remove */
+        if ($this->membership->remove() === false) {
+            return $this->failure($this->modx->lexicon('user_group_member_err_remove'));
+        }
+
+        /* unset primary group if that was this group */
+        if ($user && $userGroup) {
+            if ($user->get('primary_group') === $userGroup->get('id')) {
+                $user->set('primary_group', 0);
+                $user->save();
+            }
+        }
+
+        return $this->success('', $this->membership);
+    }
+}

--- a/core/src/Processors/Security/Group/User/Update.php
+++ b/core/src/Processors/Security/Group/User/Update.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\Security\Group\User;
+
+use MODX\Revolution\modProcessor;
+use MODX\Revolution\modUserGroupMember;
+
+/**
+ * Update a users role in a user group
+ * @param integer $usergroup The ID of the user group
+ * @param integer $user The ID of the user
+ * @package MODX\Revolution\Processors\Security\Group\User
+ */
+class Update extends modProcessor
+{
+    /** @var modUserGroupMember $membership */
+    public $membership;
+
+    /**
+     * @return bool
+     */
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('usergroup_user_edit');
+    }
+
+    /**
+     * @return array
+     */
+    public function getLanguageTopics()
+    {
+        return ['user'];
+    }
+
+    /**
+     * @return bool|string|null
+     */
+    public function initialize()
+    {
+        $user = $this->getProperty('user');
+        if (empty($user)) {
+            return $this->modx->lexicon('user_err_ns');
+        }
+        $userGroup = $this->getProperty('usergroup');
+        if (empty($userGroup)) {
+            return $this->modx->lexicon('user_group_err_ns');
+        }
+
+        $this->membership = $this->modx->getObject(modUserGroupMember::class, [
+            'member' => $this->getProperty('user', 0),
+            'user_group' => $this->getProperty('usergroup', 0),
+        ]);
+        if ($this->membership === null) {
+            return $this->modx->lexicon('user_group_member_err_nf');
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array|mixed|string
+     */
+    public function process()
+    {
+        $this->membership->fromArray($this->getProperties());
+
+        if ($this->membership->save() === false) {
+            return $this->failure($this->modx->lexicon('user_group_member_err_save'));
+        }
+
+        return $this->success('', $this->membership);
+    }
+}

--- a/manager/assets/modext/widgets/security/modx.tree.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.user.group.js
@@ -168,9 +168,9 @@ Ext.extend(MODx.tree.UserGroup,MODx.tree.Tree,{
             ,text: _('user_group_user_remove_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/group/removeUser'
-                ,user_id: user_id
-                ,group_id: group_id
+                action: 'security/group/user/remove'
+                ,user: user_id
+                ,usergroup: group_id
             }
             ,listeners: {
                 'success':{fn:this.refresh,scope:this}


### PR DESCRIPTION
Task https://github.com/modxcms/revolution/issues/14547

I checked the usage and found out those following processors are not used anymore (also they outdated, flat-file based):
'security/group/get.php'
'security/group/adduser.php'
'security/group/removeuser.php'

I didn't convert them as unused.

The last one was used in one place in extjs but I replaced the call to proper processor.

Not sure if I should remove them in this pull request.