### PR TITLE
Fix using non numeric value in expression that caused warning

### DIFF
--- a/setup/includes/new.install.php
+++ b/setup/includes/new.install.php
@@ -303,18 +303,9 @@ if ('sdk' === trim($currentVersion['distro'], '@')) {
     $setting->save();
 }
 
-$maxFileSize = ini_get('upload_max_filesize');
-$maxFileSize = trim($maxFileSize);
-$last = strtolower($maxFileSize[strlen($maxFileSize)-1]);
-switch ($last) {
-    // The 'G' modifier is available since PHP 5.1.0
-    case 'g':
-        $maxFileSize *= 1024;
-    case 'm':
-        $maxFileSize *= 1024;
-    case 'k':
-        $maxFileSize *= 1024;
-}
+$maxFileSize = trim(ini_get('upload_max_filesize'));
+$modifier = strtolower(substr($maxFileSize, -1));
+$maxFileSizeInBytes = (int) $maxFileSize * pow(1024, strpos('kmg', $modifier) + 1);
 
 $settings_maxFileSize = $modx->getObject('modSystemSetting', array('key' => 'upload_maxsize'));
 if (!$settings_maxFileSize) {
@@ -330,7 +321,7 @@ if (!$settings_maxFileSize) {
         true
     );
 }
-$settings_maxFileSize->set('value', $maxFileSize);
+$settings_maxFileSize->set('value', $maxFileSizeInBytes);
 $settings_maxFileSize->save();
 
 return true;


### PR DESCRIPTION
### What does it do?
Fixes the code which calculates bytes for system setting based on ini value. 

### Why is it needed?
In the original code, it uses a variable with text and tries to multiply it that in PHP 8 cause a warning.

```
Warning: A non-numeric value encountered in /var/www/html/public/setup/includes/new.install.php on line 314
```

![MODX Revolution 2 8 2-dev » Install](https://user-images.githubusercontent.com/303498/99811494-4e8d5880-2b56-11eb-967c-451870a31fcb.png)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15335
