### PR TITLE
Add 1-hour cache to the dashboard feeds

### DIFF
--- a/core/model/modx/processors/system/dashboard/widget/feed.class.php
+++ b/core/model/modx/processors/system/dashboard/widget/feed.class.php
@@ -40,7 +40,16 @@ class modDashboardWidgetFeedProcessor extends modProcessor
             return $this->failure();
         }
 
-        return $this->loadFeed($url);
+        $cacheKey = 'dashboard_feed/' . $feed;
+        $fromCache = $this->modx->getCacheManager()->get($cacheKey);
+        if ($fromCache) {
+            return $fromCache;
+        }
+
+        $result = $this->loadFeed($url);
+        $this->modx->getCacheManager()->set($cacheKey, $result, 3600);
+
+        return $result;
     }
 
     public function loadFeed($url)


### PR DESCRIPTION
Simple cache implementation to make sure every dashboard view doesn't hit up the RSS feed.